### PR TITLE
ci(CodeQL): actually ignore all events from dependabot

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,6 @@ name: 'CodeQL'
 
 on:
     push:
-      branches-ignore: 'dependabot/**'
     pull_request:
     schedule:
         - cron: '0 5 * * *'
@@ -16,6 +15,7 @@ jobs:
     analyze:
         name: Analyze
         runs-on: ubuntu-latest
+        if: ${{ github.actor != 'dependabot[bot]' }}
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
### **Please describe all changes made by this Pull Request and why you feel like it should be merged:**

_Please provide a clear and concise description of the changes made in this PR and the reasons why they should be merged_

Instead of ignoring all pushes to dependabot branches, this commit changes the CodeQL workflow's behavior so that all events from dependabot are ignored, in order to completely remove the need to re-run failed workflows. Additionally, pushes to dependabot branches by people who aren't dependabot are not going to be ignored anymore. As such, this makes it easier for maintainers to merge Dependabot PRs without having to worry about re-running any workflows, as well as making sure that any security flaws introduced by users touching dependabot's branches won't sneak into the bot.

 ### **Issues**

_If your pull request closes any open issues, please describe which ones. ([See here](https://help.github.com/en/articles/closing-issues-using-keywords))_

### **Checklists**

_Please tick the following checklists (by placing an x) as appropriate._

-   [x] I have read and agreed to both the [Code of Conduct](./CODE_OF_CONDUCT.md) and [Contributing Guidelines](.github/CONTRIBUTING.md) (**required**)
-   [x] Code changes have been tested **with a bot account on Discord**, or there are none. (**required**)
-   [x] Any code changes have been checked against ESLint (`npx eslint .`) and the TypeScript compiler (`npx tsc`) and there are no errors, or there are no code changes. (**required**)
