### PR TITLE
Remove dm checks and replace them

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -7,17 +7,15 @@ export default {
         .addUserOption((option) => option.setName('user').setDescription('User to ban').setRequired(true))
         .addStringOption((option) =>
             option.setName('reason').setDescription('Reason for banning the user').setRequired(false),
-        ),
+        )
+        .setDMpermissions(false),
     run: async (interaction: ChatInputCommandInteraction) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.BanMembers)) {
             return interaction.reply({
-                content: '❌ Sorry, I need the `Ban Members` permission n order to execute this command.',
+                content: '❌ Sorry, I need the `Ban Members` permission in order to execute this command.',
                 ephemeral: true,
             });
         }

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -7,14 +7,13 @@ export default {
         .addUserOption((option) => option.setName('user').setDescription('User to kick').setRequired(true))
         .addStringOption((option) =>
             option.setName('reason').setDescription('Reason for kicking the user').setRequired(false),
-        ),
+        )
+        .setDMpermissions(false),
+        
     run: async (interaction: ChatInputCommandInteraction) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.KickMembers)) {
             return interaction.reply({
                 content: '❌ Sorry, I need the `Kick Members` in order to execute this command.',

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -12,14 +12,13 @@ export default {
         .setDescription('Deletes up to 100 messages.')
         .addIntegerOption((option) =>
             option.setName('amount').setDescription('Amount of messages to delete').setRequired(true),
-        ),
+        )
+        .setDMpermissions(false),
+        
     run: async (interaction: ChatInputCommandInteraction) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.ManageMessages)) {
             return interaction.reply({
                 content: '❌ Sorry, I need the `Manage Messages` permission in order to execute this command.',

--- a/src/commands/role-info.ts
+++ b/src/commands/role-info.ts
@@ -16,14 +16,13 @@ export default {
                 .setName('show_permissions')
                 .setDescription("Whether to show the role's permissions")
                 .setRequired(false),
-        ),
+        )
+        .setDMpermissions(false),
+
     run: async (interaction: ChatInputCommandInteraction) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         const apiRole = interaction.options.getRole('role', true);
         const role: Role = interaction.guild.roles.cache.get(apiRole.id);
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7,14 +7,13 @@ export default {
         .setDescription('Displays info about your server')
         .addBooleanOption((option) =>
             option.setName('show_roles').setDescription("Whether to show the server's roles").setRequired(false),
-        ),
+        )
+        .setDMpermissions(false),
+        
     run: async (interaction: ChatInputCommandInteraction, client: Client) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         const embed = new EmbedBuilder()
             .setColor('Random')
             .setTitle(`${interaction.guild.name}`)

--- a/src/commands/unban.ts
+++ b/src/commands/unban.ts
@@ -14,14 +14,13 @@ export default {
         .addUserOption((option) => option.setName('user').setDescription('User to unban').setRequired(true))
         .addStringOption((option) =>
             option.setName('reason').setDescription('Reason for unbanning the user').setRequired(false),
-        ),
+        )
+        .setDMpermissions(false),
+        
     run: async (interaction: ChatInputCommandInteraction, client: Client) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.BanMembers)) {
             return interaction.reply({
                 content: '❌ Sorry, I need the `Ban Members` permission in order to execute this command.',

--- a/src/commands/user-info.ts
+++ b/src/commands/user-info.ts
@@ -13,14 +13,13 @@ export default {
                 .setName('show_permissions')
                 .setDescription("Whether to show the user's permissions")
                 .setRequired(false),
-        ),
+        )
+        .setDMpermissions(false),
+        
     run: async (interaction: ChatInputCommandInteraction) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
 
-        if (interaction.inGuild() === false) {
-            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
-        }
         const user = interaction.options?.getUser('user') ?? interaction.user;
 
         const member = interaction.guild.members.cache.get(user.id);


### PR DESCRIPTION
### **Please describe all changes made by this Pull Request and why you feel like it should be merged:**
This pull request removes all snippets that check if the command is ran inside a server, and replace them with the `.setDMPermission(false)` function on the builder object, which lets Discord hide the command in DMs.

### **Checklists**
_Please tick the following checklists (by placing an x) as appropriate._

-   [x] I have read and agreed to both the [Code of Conduct](https://github.com/Costpap/CostBot/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Costpap/CostBot/blob/main/.github/CONTRIBUTING.md) (**required**)
-   [x] Code changes have been tested **with a bot account on Discord**, or there are none. (**required**)
-   [ ] Any code changes have been checked against ESLint (`npx eslint .`) and the TypeScript compiler (`npx tsc`) and there are no errors, or there are no code changes. (**required**)
