### PR TITLE
Use min_value and max_value to check message count

### DIFF
--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -41,7 +41,6 @@ export default {
          * The total number of messages to bulkDelete.
          */
         const amount: number = interaction.options.getInteger('amount', true);
-        
         const textChannel = interaction.channel as TextChannel | NewsChannel;
         try {
             const deletedMessages = await textChannel.bulkDelete(amount, true);

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -11,7 +11,12 @@ export default {
         .setName('prune')
         .setDescription('Deletes up to 100 messages.')
         .addIntegerOption((option) =>
-            option.setName('amount').setDescription('Amount of messages to delete').setRequired(true),
+            option
+                .setName('amount')
+                .setDescription('Amount of messages to delete')
+                .setMinValue(1)
+                .setMaxValue(100)
+                .setRequired(true),
         )
         .setDMPermission(false),
     run: async (interaction: ChatInputCommandInteraction) => {
@@ -36,11 +41,7 @@ export default {
          * The total number of messages to bulkDelete.
          */
         const amount: number = interaction.options.getInteger('amount', true);
-
-        if (amount <= 1 || amount > 100) {
-            return interaction.reply({ content: '❌ You need to input a number between 1 and 100.', ephemeral: true });
-        }
-
+        
         const textChannel = interaction.channel as TextChannel | NewsChannel;
         try {
             const deletedMessages = await textChannel.bulkDelete(amount, true);


### PR DESCRIPTION
### **Please describe all changes made by this Pull Request and why you feel like it should be merged:**
This pull requests replaces the manual check for message count with the API's fields that allows the client to validate the number with the provided range.

### **Checklists**

_Please tick the following checklists (by placing an x) as appropriate._

-   [x] I have read and agreed to both the [Code of Conduct](https://github.com/Costpap/CostBot/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Costpap/CostBot/blob/main/.github/CONTRIBUTING.md) (**required**)
-   [x] Code changes have been tested **with a bot account on Discord**, or there are none. (**required**)
-   [x] Any code changes have been checked against ESLint (`npx eslint .`) and the TypeScript compiler (`npx tsc`) and there are no errors, or there are no code changes. (**required**)
-   [x] The contributor has been bullied by Prettier.
