### PR TITLE
Timeout command created

### DIFF
--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -7,27 +7,32 @@ export default {
     data: new SlashCommandBuilder()
         .setName('timeout')
         .setDescription('Manages the timeout of the mentioned user.')
-            .addSubcommand(subcommand => subcommand.setName('add')
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('add')
                 .setDescription('Times out a user.')
-                .addUserOption((option) => 
-                    option.setName('user')
-                    .setDescription('User to time out')
-                    .setRequired(true))
-                .addIntegerOption(option => //TODO: There are fixed times for this, so this should be a choice?
-                    option.setName('duration') 
-                    .setDescription('Duration of the timeout (in minutes)')
-                    .setRequired(true)) 
-                .addStringOption(option =>
-                    option.setName('reason')
-                    .setDescription('Reason for timing out the user')
-                    .setRequired(true))) 
-            .addSubcommand(subcommand => subcommand.setName('remove')
+                .addUserOption((option) => option.setName('user').setDescription('User to time out').setRequired(true))
+                .addIntegerOption(
+                    (
+                        option, //TODO: There are fixed times for this, so this should be a choice?
+                    ) =>
+                        option
+                            .setName('duration')
+                            .setDescription('Duration of the timeout (in minutes)')
+                            .setRequired(true),
+                )
+                .addStringOption((option) =>
+                    option.setName('reason').setDescription('Reason for timing out the user').setRequired(true),
+                ),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('remove')
                 .setDescription('Removes the timeout of a user.')
-                .addUserOption((option) => 
-                    option.setName('user')
-                    .setDescription('User to remove the timeout of')
-                    .setRequired(true))) 
-        ,
+                .addUserOption((option) =>
+                    option.setName('user').setDescription('User to remove the timeout of').setRequired(true),
+                ),
+        ),
     run: async (interaction: ChatInputCommandInteraction) => {
         if (!interaction.isChatInputCommand()) return;
 
@@ -57,7 +62,8 @@ export default {
             return interaction.reply({ content: "Aww, please don't time out yourself! 💖", ephemeral: true });
         }
 
-        if (member.permissions.has('Administrator') || member.id === interaction.guild.ownerId) { //Permission check for Admins and server owners - they cannot be timed out
+        if (member.permissions.has('Administrator') || member.id === interaction.guild.ownerId) {
+            //Permission check for Admins and server owners - they cannot be timed out
             return interaction.reply({
                 content: '❌ I cannot time out this user! \n**Admins and the server owner cannot be timed out.**',
                 ephemeral: true,
@@ -65,10 +71,13 @@ export default {
         }
 
         if (interaction.options.getSubcommand() === 'add') {
-            let response = `⏳ Timed out \`${member.user.tag} (${member.id})\`.`;
+            const response = `⏳ Timed out \`${member.user.tag} (${member.id})\`.`;
 
             try {
-                await member.timeout(interaction.options.getInteger('duration') * 60 * 1000, interaction.options.getString('reason'))
+                await member.timeout(
+                    interaction.options.getInteger('duration') * 60 * 1000,
+                    interaction.options.getString('reason'),
+                );
                 interaction.reply({ content: response, ephemeral: true });
             } catch (error) {
                 console.error(error);
@@ -82,20 +91,20 @@ export default {
         }
 
         if (interaction.options.getSubcommand() === 'remove') {
-            let response = `⌛ Timeout of \`${member.user.tag} (${member.id})\` has been removed.`;
+            const response = `⌛ Timeout of \`${member.user.tag} (${member.id})\` has been removed.`;
 
             try {
-                await member.timeout(null)
+                await member.timeout(null);
                 interaction.reply({ content: response, ephemeral: true });
             } catch (error) {
                 console.error(error);
                 return interaction.reply({
-                    content: `❌ I encountered an error while trying remove the timeout of \`${member.user.tag}\`: \n\`\`\`${
-                        error?.message || error
-                    }\`\`\``,
+                    content: `❌ I encountered an error while trying remove the timeout of \`${
+                        member.user.tag
+                    }\`: \n\`\`\`${error?.message || error}\`\`\``,
                     ephemeral: true,
                 });
             }
         }
-    }
-}
+    },
+};

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -89,7 +89,7 @@ export default {
                 const duration = interaction.options.getString('duration', true);
                 const msDuration = ms(duration);
 
-                if (msDuration == null) {
+                if (typeof msDuration !== 'number') {
                     return interaction.reply({
                         content: '❌ Please specify a valid timeout duration.',
                         ephemeral: true,
@@ -103,18 +103,24 @@ export default {
                     });
                 }
 
-                let response = `✅ Timed out \`${member.user.tag} (${member.id})\`.`;
-
-                if (!interaction.options.getBoolean('silent')) {
-                    const notified = await notifyUser(user, interaction, 'timed out');
-                    if (!notified) response += "\n\n⚠️ Couldn't send DM to user.";
+                if (msDuration <= 0) {
+                    return interaction.reply({
+                        content: '❌ The duration of the timeout must be less than or equal to 28 days!',
+                        ephemeral: true,
+                    });
                 }
+
+                let response = `✅ Timed out \`${member.user.tag} (${member.id})\`.`;
 
                 try {
                     await member.timeout(
                         msDuration,
                         interaction.options?.getString('reason') ? `${interaction.options?.getString('reason')}` : '',
                     );
+                    if (!interaction.options.getBoolean('silent')) {
+                        const notified = await notifyUser(user, interaction, 'timed out');
+                        if (!notified) response += "\n\n⚠️ Couldn't send DM to user.";
+                    }
                     return interaction.reply({ content: response, ephemeral: true });
                 } catch (error) {
                     console.error(error);

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -14,20 +14,17 @@ export default {
                 .setName('add')
                 .setDescription('Times out the selected user.')
                 .addUserOption((option) => option.setName('user').setDescription('User to time out').setRequired(true))
-                .addStringOption(
-                    (
-                        option,
-                    ) =>
-                        option
-                            .setName('duration')
-                            .setDescription('Duration of the timeout (e.g. 10sec/60m/2.5 hrs)')
-                            .setRequired(true),
+                .addStringOption((option) =>
+                    option
+                        .setName('duration')
+                        .setDescription('Duration of the timeout (e.g. 10sec/60m/2.5 hrs)')
+                        .setRequired(true),
                 )
                 .addStringOption((option) =>
                     option.setName('reason').setDescription('Reason for timing out the user').setRequired(false),
                 )
                 .addBooleanOption((option) =>
-                option.setName('silent').setDescription('Whether or not to DM the user').setRequired(false),
+                    option.setName('silent').setDescription('Whether or not to DM the user').setRequired(false),
                 ),
         )
         .addSubcommand((subcommand) =>
@@ -39,7 +36,7 @@ export default {
                 )
                 .addStringOption((option) =>
                     option.setName('reason').setDescription('Reason for removing the timeout').setRequired(false),
-                )
+                ),
         ),
     run: async (interaction: ChatInputCommandInteraction) => {
         // Typeguard in order to ensure having access to ChatInputCommand interaction options.
@@ -68,7 +65,10 @@ export default {
         const member = await interaction.guild.members.fetch(user.id);
 
         if (!member) {
-            return interaction.reply({ content: '❌ You need to specify a valid user to manage their timeout!', ephemeral: true });
+            return interaction.reply({
+                content: '❌ You need to specify a valid user to manage their timeout!',
+                ephemeral: true,
+            });
         }
 
         if (interaction.options.getSubcommand() === 'add') {
@@ -89,16 +89,14 @@ export default {
 
             if (msDuration == null) {
                 return interaction.reply({
-                    content:
-                        '❌ The format of the timeout duration is invalid!',
+                    content: '❌ The format of the timeout duration is invalid!',
                     ephemeral: true,
                 });
             }
 
             if (msDuration <= 0) {
                 return interaction.reply({
-                    content:
-                        '❌ The duration of the timeout must be greater than 0!',
+                    content: '❌ The duration of the timeout must be greater than 0!',
                     ephemeral: true,
                 });
             }
@@ -139,13 +137,13 @@ export default {
                     ephemeral: true,
                 });
             }
-            
+
             const response = `⌛ Removed the timeout from \`${member.user.tag} (${member.id})\``;
 
             try {
                 await member.timeout(
                     null,
-                    interaction.options?.getString('reason') ? `${interaction.options?.getString('reason')}` : ''
+                    interaction.options?.getString('reason') ? `${interaction.options?.getString('reason')}` : '',
                 );
                 return interaction.reply({ content: response, ephemeral: true });
             } catch (error) {

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -2,39 +2,52 @@
 
 //imports
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import { notifyUser } from '../utils/misc';
+import ms from 'ms';
 
 export default {
     data: new SlashCommandBuilder()
         .setName('timeout')
-        .setDescription('Manages the timeout of the mentioned user.')
+        .setDescription('Manages the timeout of a selected user.')
         .addSubcommand((subcommand) =>
             subcommand
                 .setName('add')
-                .setDescription('Times out a user.')
+                .setDescription('Times out the selected user.')
                 .addUserOption((option) => option.setName('user').setDescription('User to time out').setRequired(true))
-                .addIntegerOption(
+                .addStringOption(
                     (
-                        option, //TODO: There are fixed times for this, so this should be a choice?
+                        option,
                     ) =>
                         option
                             .setName('duration')
-                            .setDescription('Duration of the timeout (in minutes)')
+                            .setDescription('Duration of the timeout (e.g. 10sec/60m/2.5 hrs)')
                             .setRequired(true),
                 )
                 .addStringOption((option) =>
-                    option.setName('reason').setDescription('Reason for timing out the user').setRequired(true),
+                    option.setName('reason').setDescription('Reason for timing out the user').setRequired(false),
+                )
+                .addBooleanOption((option) =>
+                option.setName('silent').setDescription('Whether or not to DM the user').setRequired(false),
                 ),
         )
         .addSubcommand((subcommand) =>
             subcommand
                 .setName('remove')
-                .setDescription('Removes the timeout of a user.')
+                .setDescription('Removes timeout from a user.')
                 .addUserOption((option) =>
-                    option.setName('user').setDescription('User to remove the timeout of').setRequired(true),
-                ),
+                    option.setName('user').setDescription('User to remove the timeout from').setRequired(true),
+                )
+                .addStringOption((option) =>
+                    option.setName('reason').setDescription('Reason for removing the timeout').setRequired(false),
+                )
         ),
     run: async (interaction: ChatInputCommandInteraction) => {
+        // Typeguard in order to ensure having access to ChatInputCommand interaction options.
         if (!interaction.isChatInputCommand()) return;
+
+        if (interaction.inGuild() === false) {
+            return interaction.reply({ content: "❌ I can't execute this command inside DMs!", ephemeral: true });
+        }
 
         if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.ModerateMembers)) {
             return interaction.reply({
@@ -55,30 +68,54 @@ export default {
         const member = await interaction.guild.members.fetch(user.id);
 
         if (!member) {
-            return interaction.reply({ content: '❌ You need to specify a valid user to time out!', ephemeral: true });
-        }
-
-        if (member.id === interaction.user.id) {
-            return interaction.reply({ content: "Aww, please don't time out yourself! 💖", ephemeral: true });
-        }
-
-        if (member.permissions.has('Administrator') || member.id === interaction.guild.ownerId) {
-            //Permission check for Admins and server owners - they cannot be timed out
-            return interaction.reply({
-                content: '❌ I cannot time out this user! \n**Admins and the server owner cannot be timed out.**',
-                ephemeral: true,
-            });
+            return interaction.reply({ content: '❌ You need to specify a valid user to manage their timeout!', ephemeral: true });
         }
 
         if (interaction.options.getSubcommand() === 'add') {
-            const response = `⏳ Timed out \`${member.user.tag} (${member.id})\`.`;
+            if (member.id === interaction.user.id) {
+                return interaction.reply({ content: "Aww, please don't time out yourself! 💖", ephemeral: true });
+            }
+
+            if (member.moderatable === false) {
+                return interaction.reply({
+                    content:
+                        '❌ I cannot time out this user! \n**Please make sure that my highest role is above theirs.**',
+                    ephemeral: true,
+                });
+            }
+
+            const duration = interaction.options.getString('duration', true);
+            const msDuration = ms(duration);
+
+            if (msDuration == null) {
+                return interaction.reply({
+                    content:
+                        '❌ The format of the timeout duration is invalid!',
+                    ephemeral: true,
+                });
+            }
+
+            if (msDuration <= 0) {
+                return interaction.reply({
+                    content:
+                        '❌ The duration of the timeout must be greater than 0!',
+                    ephemeral: true,
+                });
+            }
+
+            let response = `⏳ Timed out \`${member.user.tag} (${member.id})\`.`;
+
+            if (!interaction.options.getBoolean('silent')) {
+                const notified = await notifyUser(user, interaction, 'timed out');
+                if (!notified) response += "\n\n⚠️ Couldn't send DM to user.";
+            }
 
             try {
                 await member.timeout(
-                    interaction.options.getInteger('duration') * 60 * 1000,
-                    interaction.options.getString('reason'),
+                    msDuration,
+                    interaction.options?.getString('reason') ? `${interaction.options?.getString('reason')}` : '',
                 );
-                interaction.reply({ content: response, ephemeral: true });
+                return interaction.reply({ content: response, ephemeral: true });
             } catch (error) {
                 console.error(error);
                 return interaction.reply({
@@ -91,15 +128,30 @@ export default {
         }
 
         if (interaction.options.getSubcommand() === 'remove') {
-            const response = `⌛ Timeout of \`${member.user.tag} (${member.id})\` has been removed.`;
+            if (!member.isCommunicationDisabled()) {
+                return interaction.reply({ content: '❌ This user is not currently timed out.', ephemeral: true });
+            }
+
+            if (member.moderatable === false) {
+                return interaction.reply({
+                    content:
+                        '❌ I cannot remove the timeout from this user! \n**Please make sure that my highest role is above theirs.**',
+                    ephemeral: true,
+                });
+            }
+            
+            const response = `⌛ Removed the timeout from \`${member.user.tag} (${member.id})\``;
 
             try {
-                await member.timeout(null);
-                interaction.reply({ content: response, ephemeral: true });
+                await member.timeout(
+                    null,
+                    interaction.options?.getString('reason') ? `${interaction.options?.getString('reason')}` : ''
+                );
+                return interaction.reply({ content: response, ephemeral: true });
             } catch (error) {
                 console.error(error);
                 return interaction.reply({
-                    content: `❌ I encountered an error while trying remove the timeout of \`${
+                    content: `❌ I encountered an error while trying remove the timeout from \`${
                         member.user.tag
                     }\`: \n\`\`\`${error?.message || error}\`\`\``,
                     ephemeral: true,

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -153,7 +153,7 @@ export default {
                 } catch (error) {
                     console.error(error);
                     return interaction.reply({
-                        content: `❌ I encountered an error while trying remove the timeout from \`${
+                        content: `❌ I encountered an error while trying remove the timeout for \`${
                             member.user.tag
                         }\`: \n\`\`\`${error?.message || error}\`\`\``,
                         ephemeral: true,

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -1,0 +1,101 @@
+//Template: https://github.com/Costpap/CostBot/blob/main/src/commands/kick.ts
+
+//imports
+import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('timeout')
+        .setDescription('Manages the timeout of the mentioned user.')
+            .addSubcommand(subcommand => subcommand.setName('add')
+                .setDescription('Times out a user.')
+                .addUserOption((option) => 
+                    option.setName('user')
+                    .setDescription('User to time out')
+                    .setRequired(true))
+                .addIntegerOption(option => //TODO: There are fixed times for this, so this should be a choice?
+                    option.setName('duration') 
+                    .setDescription('Duration of the timeout (in minutes)')
+                    .setRequired(true)) 
+                .addStringOption(option =>
+                    option.setName('reason')
+                    .setDescription('Reason for timing out the user')
+                    .setRequired(true))) 
+            .addSubcommand(subcommand => subcommand.setName('remove')
+                .setDescription('Removes the timeout of a user.')
+                .addUserOption((option) => 
+                    option.setName('user')
+                    .setDescription('User to remove the timeout of')
+                    .setRequired(true))) 
+        ,
+    run: async (interaction: ChatInputCommandInteraction) => {
+        if (!interaction.isChatInputCommand()) return;
+
+        if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.ModerateMembers)) {
+            return interaction.reply({
+                content: '❌ Sorry, I need the `Moderate Members` in order to execute this command.',
+                ephemeral: true,
+            });
+        }
+        if (typeof interaction.member.permissions === 'string')
+            return interaction.reply({ content: '❌ Unknown permissions. Please try again later.', ephemeral: true });
+        else if (!interaction.member.permissions.has(PermissionFlagsBits.ModerateMembers)) {
+            return interaction.reply({
+                content: '⛔ You need the `Moderate Members` permission in order to use this command!',
+                ephemeral: true,
+            });
+        }
+
+        const user = interaction.options.getUser('user', true);
+        const member = await interaction.guild.members.fetch(user.id);
+
+        if (!member) {
+            return interaction.reply({ content: '❌ You need to specify a valid user to time out!', ephemeral: true });
+        }
+
+        if (member.id === interaction.user.id) {
+            return interaction.reply({ content: "Aww, please don't time out yourself! 💖", ephemeral: true });
+        }
+
+        if (member.permissions.has('Administrator') || member.id === interaction.guild.ownerId) { //Permission check for Admins and server owners - they cannot be timed out
+            return interaction.reply({
+                content: '❌ I cannot time out this user! \n**Admins and the server owner cannot be timed out.**',
+                ephemeral: true,
+            });
+        }
+
+        if (interaction.options.getSubcommand() === 'add') {
+            let response = `⏳ Timed out \`${member.user.tag} (${member.id})\`.`;
+
+            try {
+                await member.timeout(interaction.options.getInteger('duration') * 60 * 1000, interaction.options.getString('reason'))
+                interaction.reply({ content: response, ephemeral: true });
+            } catch (error) {
+                console.error(error);
+                return interaction.reply({
+                    content: `❌ I encountered an error while trying to time out \`${member.user.tag}\`: \n\`\`\`${
+                        error?.message || error
+                    }\`\`\``,
+                    ephemeral: true,
+                });
+            }
+        }
+
+        if (interaction.options.getSubcommand() === 'remove') {
+            let response = `⌛ Timeout of \`${member.user.tag} (${member.id})\` has been removed.`;
+
+            try {
+                await member.timeout(null)
+                interaction.reply({ content: response, ephemeral: true });
+            } catch (error) {
+                console.error(error);
+                return interaction.reply({
+                    content: `❌ I encountered an error while trying remove the timeout of \`${member.user.tag}\`: \n\`\`\`${
+                        error?.message || error
+                    }\`\`\``,
+                    ephemeral: true,
+                });
+            }
+        }
+    }
+}

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -30,7 +30,7 @@ export default {
         .addSubcommand((subcommand) =>
             subcommand
                 .setName('remove')
-                .setDescription('Removes timeout from a user.')
+                .setDescription('Removes a timeout from a user.')
                 .addUserOption((option) =>
                     option.setName('user').setDescription('User to remove the timeout from').setRequired(true),
                 )

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -142,7 +142,7 @@ export default {
                     });
                 }
 
-                const response = `✅ Removed the timeout from \`${member.user.tag} (${member.id})\``;
+                const response = `✅ Removed the timeout for \`${member.user.tag} (${member.id})\``;
 
                 try {
                     await member.timeout(

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -45,7 +45,7 @@ export default {
 
         if (!interaction.guild.members.me.permissions.has(PermissionFlagsBits.ModerateMembers)) {
             return interaction.reply({
-                content: '❌ Sorry, I need the `Timeout Members` in order to execute this command.',
+                content: '❌ Sorry, I need the `Timeout Members` permission in order to execute this command.',
                 ephemeral: true,
             });
         }

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -1,6 +1,3 @@
-//Template: https://github.com/Costpap/CostBot/blob/main/src/commands/kick.ts
-
-//imports
 import { ChatInputCommandInteraction, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import { notifyUser } from '../utils/misc';
 import ms from 'ms';


### PR DESCRIPTION
### **Please describe all changes made by this Pull Request and why you feel like it should be merged:**

I have created the timeout command. It is split into two subcommands: add and remove. 

Features checks in a similiar fashion as it is done in other commands of this bot:
- The bot's and also the executing member's permission to ModerateMembers is checked. 
- It is check whether the supplied user is valid - however this might be unnecessary, since the UserOption only accepts valid users - but it was done like that in other commands, so I went for consistency
- Issuers of this command cannot time out themselves
- Admins and the server owner cannot be timed out.

Does not feature a DM, as the timeout reason and time can be directly seen by the user, but can be added if requested.

### **Issues**

This PR closes #468.

### **Checklists**

-   [x] I have read and agreed to both the [Code of Conduct](https://github.com/Costpap/CostBot/blob/main/.github/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Costpap/CostBot/blob/main/.github/CONTRIBUTING.md) (**required**)
-   [x] Code changes have been tested **with a bot account on Discord**, or there are none. (**required**)
-   [x] Any code changes have been checked against ESLint (`npx eslint .`) and the TypeScript compiler (`npx tsc`) and there are no errors, or there are no code changes. (**required**)
